### PR TITLE
Pull latest changes from main (#108)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'docker'
 apply plugin: 'war'
 
 group = 'conorheffron'
-version = '3.1.3'
+version = '3.1.4'
 description = "Sample Data Manager"
 
 sourceCompatibility = 17
@@ -32,7 +32,7 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-maven-plugin', version: '3.2.5'
     implementation group: 'com.rabbitmq', name: 'amqp-client', version: '5.21.0'
     implementation group: 'io.searchbox', name: 'jest', version:'6.3.1'
-    implementation group: 'org.elasticsearch', name: 'elasticsearch', version:'8.13.2'
+    implementation group: 'org.elasticsearch', name: 'elasticsearch', version:'8.13.3'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version:'1.5.22.RELEASE'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version:'1.5.22.RELEASE'
     implementation group: 'mysql', name: 'mysql-connector-java', version:'8.0.33'


### PR DESCRIPTION
* Bump org.elasticsearch:elasticsearch from 8.13.2 to 8.13.3 (#107)

Bumps [org.elasticsearch:elasticsearch](https://github.com/elastic/elasticsearch) from 8.13.2 to 8.13.3.
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Changelog](https://github.com/elastic/elasticsearch/blob/main/CHANGELOG.md)
- [Commits](https://github.com/elastic/elasticsearch/compare/v8.13.2...v8.13.3)

---
updated-dependencies:
- dependency-name: org.elasticsearch:elasticsearch dependency-type: direct:production update-type: version-update:semver-patch ...





* Update build.gradle (#109)

---------