### PR TITLE
Bump jakarta.ws.rs:jakarta.ws.rs-api from 3.1.0 to 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation group: 'jakarta.servlet.jsp.jstl', name: 'jakarta.servlet.jsp.jstl-api', version: '3.0.0'
     implementation group: 'org.glassfish.web', name: 'jakarta.servlet.jsp.jstl', version: '2.0.0'
     implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.1.0'
-    implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.1.0'
+    implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '4.0.0'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version:'3.3.1') {


### PR DESCRIPTION
Bumps jakarta.ws.rs:jakarta.ws.rs-api from 3.1.0 to 4.0.0.

---
updated-dependencies:
- dependency-name: jakarta.ws.rs:jakarta.ws.rs-api dependency-type: direct:production update-type: version-update:semver-major ...