### PR TITLE
Potential fix for code scanning alert no. 63: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/ironoc-db/security/code-scanning/63](https://github.com/conorheffron/ironoc-db/security/code-scanning/63)

To fix the issue, add a `permissions` block to the workflow. Since the workflow does not appear to require write access to repository contents or other resources, the permissions can be limited to `contents: read`. This ensures that the workflow has only the minimal access required to complete its tasks.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. Alternatively, it can be added to the specific job (`build`) if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
