### PR TITLE
Refactor person form binding to use DTO and dedicated mapper

### DIFF
--- a/src/integration-test/java/com.ironoc.db.controller/PersonControllerIntegrationTest.java
+++ b/src/integration-test/java/com.ironoc.db.controller/PersonControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.ironoc.db.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ironoc.db.config.IronocDbConfig;
 import com.ironoc.db.dao.PersonDao;
+import com.ironoc.db.dto.PersonDto;
 import com.ironoc.db.model.Employer;
 import com.ironoc.db.model.Person;
 import org.junit.Before;
@@ -165,9 +166,17 @@ public class PersonControllerIntegrationTest {
 
         given(personDaoMock.findAll()).willReturn(persons).willReturn(persons);
 
+        PersonDto personDto = PersonDto.builder()
+                .firstName(person.getFirstName())
+                .surname(person.getSurname())
+                .age(person.getAge())
+                .title(person.getTitle())
+                .id(person.getId())
+                .build();
+
         // when
         MockHttpServletResponse response = mockMvc.perform(post("/add")
-                        .flashAttr("person", person)
+                        .flashAttr("person", personDto)
                         .accept(MediaType.APPLICATION_JSON)).andExpect(status().isFound())
                 .andReturn().getResponse();
 
@@ -188,7 +197,7 @@ public class PersonControllerIntegrationTest {
 
         // when
         MockHttpServletResponse response = mockMvc.perform(get("/add")
-                        .flashAttr("person", Person.builder().build())
+                        .flashAttr("person", PersonDto.builder().build())
                         .accept(MediaType.APPLICATION_JSON)).andExpect(status().isMethodNotAllowed())
                 .andReturn().getResponse();
 

--- a/src/main/java/com/ironoc/db/controller/PersonController.java
+++ b/src/main/java/com/ironoc/db/controller/PersonController.java
@@ -93,8 +93,7 @@ public class PersonController {
 			map.addAttribute("person", person);
 			return "edit-person";
 		}
-		person.setId(id.longValue());
-		personService.addPerson(personMapper.toPerson(person));
+		personService.addPerson(personMapper.toPerson(id.longValue(), person));
 		return "redirect:/";
 	}
 }

--- a/src/main/java/com/ironoc/db/controller/PersonController.java
+++ b/src/main/java/com/ironoc/db/controller/PersonController.java
@@ -2,6 +2,7 @@ package com.ironoc.db.controller;
 
 import module java.base;
 
+import com.ironoc.db.dto.PersonDto;
 import com.ironoc.db.model.Person;
 import com.ironoc.db.service.PersonService;
 import jakarta.validation.Valid;
@@ -33,13 +34,13 @@ public class PersonController {
 		
 		List<Person> personslist = personService.getAllPersons();
         map.addAttribute("personsList", personslist);
-        map.addAttribute("person", Person.builder().build());
+        map.addAttribute("person", PersonDto.builder().build());
 
         return "index";
 	}
 	
 	@PostMapping(value = "/add")
-	public String addPerson(ModelMap map, @Valid @ModelAttribute("person") Person person,
+	public String addPerson(ModelMap map, @Valid @ModelAttribute("person") PersonDto person,
 							BindingResult result) {
 		log.info("Entering personController.addPerson: map={}, person={}", map, person);
 		
@@ -50,7 +51,7 @@ public class PersonController {
 			return "index";
 		}
 
-		personService.addPerson(person);
+		personService.addPerson(toPerson(person));
 		return "redirect:/";
 	}
     
@@ -72,7 +73,7 @@ public class PersonController {
 		log.info("Entering personController.showEditView: ID={}, model={}", id, model.asMap());
 		Optional<Person> person = personService.findPersonById(id.longValue());
 		if (person.isPresent()) {
-			model.addAttribute("person", person.get());
+			model.addAttribute("person", toPersonDto(person.get()));
 		} else {
 			// no matching entries to delete
 			log.error("There are no matching entries to delete for id={}", id);
@@ -81,15 +82,36 @@ public class PersonController {
 	}
 
 	@PostMapping("/update/{id}")
-	public String updatePerson(ModelMap map, @PathVariable("id") Integer id, @Valid Person person,
+	public String updatePerson(ModelMap map, @PathVariable("id") Integer id, @Valid @ModelAttribute("person") PersonDto person,
 							   BindingResult result) {
-		log.info("Entering personController.updatePerson: ID={}, person={}", id, person.toString());
+		log.info("Entering personController.updatePerson: ID={}, person={}", id, person);
 		if (result.hasErrors()) {
 			person.setId(id.longValue());
 			map.addAttribute("person", person);
 			return "edit-person";
 		}
-		personService.addPerson(person);
+		person.setId(id.longValue());
+		personService.addPerson(toPerson(person));
 		return "redirect:/";
+	}
+
+	private Person toPerson(PersonDto personDto) {
+		return Person.builder()
+				.id(personDto.getId())
+				.title(personDto.getTitle())
+				.firstName(personDto.getFirstName())
+				.surname(personDto.getSurname())
+				.age(personDto.getAge())
+				.build();
+	}
+
+	private PersonDto toPersonDto(Person person) {
+		return PersonDto.builder()
+				.id(person.getId())
+				.title(person.getTitle())
+				.firstName(person.getFirstName())
+				.surname(person.getSurname())
+				.age(person.getAge())
+				.build();
 	}
 }

--- a/src/main/java/com/ironoc/db/controller/PersonController.java
+++ b/src/main/java/com/ironoc/db/controller/PersonController.java
@@ -44,7 +44,7 @@ public class PersonController {
     }
 
     @PostMapping(value = "/add")
-    public String addPerson(ModelMap map, @Valid @ModelAttribute("person") Person person,
+    public String addPerson(ModelMap map, @Valid @ModelAttribute("person") PersonDto person,
                             BindingResult result) {
         log.info("Entering personController.addPerson: map={}, person={}", map, person);
 
@@ -56,7 +56,7 @@ public class PersonController {
             return "index";
         }
 
-        personService.addPerson(person);
+        personService.addPerson(personMapper.toPerson(person));
         return "redirect:/";
     }
 

--- a/src/main/java/com/ironoc/db/controller/PersonController.java
+++ b/src/main/java/com/ironoc/db/controller/PersonController.java
@@ -78,7 +78,7 @@ public class PersonController {
         log.info("Entering personController.showEditView: ID={}, model={}", id, model.asMap());
         Optional<Person> person = personService.findPersonById(id.longValue());
         if (person.isPresent()) {
-            model.addAttribute("person", person.get());
+            model.addAttribute("person", personMapper.toPersonDto(person.get()));
         } else {
             // no matching entries to delete
             log.error("There are no matching entries to delete for id={}", id);
@@ -87,16 +87,15 @@ public class PersonController {
     }
 
     @PostMapping("/update/{id}")
-    public String updatePerson(ModelMap map, @PathVariable("id") Integer id, @Valid Person person,
+    public String updatePerson(ModelMap map, @PathVariable("id") Integer id, @Valid @ModelAttribute("person") PersonDto person,
                                BindingResult result) {
-        log.info("Entering personController.updatePerson: ID={}, person={}", id, person.toString());
+        log.info("Entering personController.updatePerson: ID={}, person={}", id, person);
         if (result.hasErrors()) {
             person.setId(id.longValue());
             map.addAttribute("person", person);
             return "edit-person";
         }
-        person.setId(id.longValue());
-        personService.addPerson(person);
+        personService.addPerson(personMapper.toPerson(id.longValue(), person));
         return "redirect:/";
     }
 }

--- a/src/main/java/com/ironoc/db/controller/PersonController.java
+++ b/src/main/java/com/ironoc/db/controller/PersonController.java
@@ -3,6 +3,7 @@ package com.ironoc.db.controller;
 import module java.base;
 
 import com.ironoc.db.dto.PersonDto;
+import com.ironoc.db.mapper.PersonMapper;
 import com.ironoc.db.model.Person;
 import com.ironoc.db.service.PersonService;
 import jakarta.validation.Valid;
@@ -23,9 +24,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 public class PersonController {
 
     private final PersonService personService;
+    private final PersonMapper personMapper;
 
-    public PersonController(@Autowired PersonService personService) {
+    public PersonController(@Autowired PersonService personService, @Autowired PersonMapper personMapper) {
         this.personService = personService;
+        this.personMapper = personMapper;
     }
 
 	@GetMapping(value = "/")
@@ -51,7 +54,7 @@ public class PersonController {
 			return "index";
 		}
 
-		personService.addPerson(toPerson(person));
+		personService.addPerson(personMapper.toPerson(person));
 		return "redirect:/";
 	}
     
@@ -73,7 +76,7 @@ public class PersonController {
 		log.info("Entering personController.showEditView: ID={}, model={}", id, model.asMap());
 		Optional<Person> person = personService.findPersonById(id.longValue());
 		if (person.isPresent()) {
-			model.addAttribute("person", toPersonDto(person.get()));
+			model.addAttribute("person", personMapper.toPersonDto(person.get()));
 		} else {
 			// no matching entries to delete
 			log.error("There are no matching entries to delete for id={}", id);
@@ -91,27 +94,7 @@ public class PersonController {
 			return "edit-person";
 		}
 		person.setId(id.longValue());
-		personService.addPerson(toPerson(person));
+		personService.addPerson(personMapper.toPerson(person));
 		return "redirect:/";
-	}
-
-	private Person toPerson(PersonDto personDto) {
-		return Person.builder()
-				.id(personDto.getId())
-				.title(personDto.getTitle())
-				.firstName(personDto.getFirstName())
-				.surname(personDto.getSurname())
-				.age(personDto.getAge())
-				.build();
-	}
-
-	private PersonDto toPersonDto(Person person) {
-		return PersonDto.builder()
-				.id(person.getId())
-				.title(person.getTitle())
-				.firstName(person.getFirstName())
-				.surname(person.getSurname())
-				.age(person.getAge())
-				.build();
 	}
 }

--- a/src/main/java/com/ironoc/db/dto/PersonDto.java
+++ b/src/main/java/com/ironoc/db/dto/PersonDto.java
@@ -1,0 +1,39 @@
+package com.ironoc.db.dto;
+
+import module java.base;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PersonDto {
+
+    private Long id;
+
+    @NotEmpty(message = "Title is not defined.")
+    @Size(min = 2, max = 5, message = "Title should be between 2-5 characters.")
+    private String title;
+
+    @NotEmpty(message = "First Name is not defined.")
+    @Size(min = 3, max = 30, message = "First Name should be between 3-30 characters.")
+    private String firstName;
+
+    @NotEmpty(message = "Surname is not defined.")
+    @Size(min = 3, max = 30, message = "Surname should be between 3-30 characters.")
+    private String surname;
+
+    @Min(value = 1, message = "Age is less than 1.")
+    @Max(value = 90, message = "Age is greater than 90.")
+    @NotNull(message = "Age is not defined.")
+    private Integer age;
+}

--- a/src/main/java/com/ironoc/db/mapper/PersonMapper.java
+++ b/src/main/java/com/ironoc/db/mapper/PersonMapper.java
@@ -1,0 +1,31 @@
+package com.ironoc.db.mapper;
+
+import module java.base;
+
+import com.ironoc.db.dto.PersonDto;
+import com.ironoc.db.model.Person;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PersonMapper {
+
+    public Person toPerson(PersonDto personDto) {
+        return Person.builder()
+                .id(personDto.getId())
+                .title(personDto.getTitle())
+                .firstName(personDto.getFirstName())
+                .surname(personDto.getSurname())
+                .age(personDto.getAge())
+                .build();
+    }
+
+    public PersonDto toPersonDto(Person person) {
+        return PersonDto.builder()
+                .id(person.getId())
+                .title(person.getTitle())
+                .firstName(person.getFirstName())
+                .surname(person.getSurname())
+                .age(person.getAge())
+                .build();
+    }
+}

--- a/src/main/java/com/ironoc/db/mapper/PersonMapper.java
+++ b/src/main/java/com/ironoc/db/mapper/PersonMapper.java
@@ -10,8 +10,12 @@ import org.springframework.stereotype.Component;
 public class PersonMapper {
 
     public Person toPerson(PersonDto personDto) {
+        return toPerson(null, personDto);
+    }
+
+    public Person toPerson(Long id, PersonDto personDto) {
         return Person.builder()
-                .id(personDto.getId())
+                .id(id)
                 .title(personDto.getTitle())
                 .firstName(personDto.getFirstName())
                 .surname(personDto.getSurname())

--- a/src/test/java/com/ironoc/db/controller/PersonControllerTest.java
+++ b/src/test/java/com/ironoc/db/controller/PersonControllerTest.java
@@ -152,6 +152,7 @@ public class PersonControllerTest {
         verify(bindingResultMock).hasErrors();
         verify(personServiceMock, never()).addPerson(ArgumentMatchers.any(Person.class));
         verify(personServiceMock).getAllPersons();
+        verify(modelMapMock).addAttribute("person", personDtoMock);
 
         assertThat(result, is("index"));
     }

--- a/src/test/java/com/ironoc/db/controller/PersonControllerTest.java
+++ b/src/test/java/com/ironoc/db/controller/PersonControllerTest.java
@@ -106,13 +106,12 @@ public class PersonControllerTest {
     @Test
     public void test_updatePerson_success() {
         when(bindingResultMock.hasErrors()).thenReturn(false);
-        when(personMapperMock.toPerson(personDtoMock)).thenReturn(personMock);
+        when(personMapperMock.toPerson(TEST_ID.longValue(), personDtoMock)).thenReturn(personMock);
 
         String result = personController.updatePerson(modelMapMock, TEST_ID, personDtoMock, bindingResultMock);
 
         verify(bindingResultMock).hasErrors();
-        verify(personDtoMock).setId(TEST_ID.longValue());
-        verify(personMapperMock).toPerson(personDtoMock);
+        verify(personMapperMock).toPerson(TEST_ID.longValue(), personDtoMock);
         verify(personServiceMock).addPerson(personMock);
 
         assertThat(result, is("redirect:/"));

--- a/src/test/java/com/ironoc/db/controller/PersonControllerTest.java
+++ b/src/test/java/com/ironoc/db/controller/PersonControllerTest.java
@@ -2,6 +2,8 @@ package com.ironoc.db.controller;
 
 import module java.base;
 
+import com.ironoc.db.dto.PersonDto;
+import com.ironoc.db.mapper.PersonMapper;
 import com.ironoc.db.model.Person;
 import com.ironoc.db.service.PersonService;
 import org.junit.Before;
@@ -15,21 +17,28 @@ import org.springframework.ui.Model;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PersonControllerTest {
 
     @InjectMocks
-    private PersonController personController;// controller under test
+    private PersonController personController;
 
     @Mock
     private PersonService personServiceMock;
+
+    @Mock
+    private PersonMapper personMapperMock;
 
     @Mock
     private ModelMap modelMapMock;
@@ -41,44 +50,39 @@ public class PersonControllerTest {
     private Person personMock;
 
     @Mock
+    private PersonDto personDtoMock;
+
+    @Mock
     private BindingResult bindingResultMock;
 
-    // test variables
     private static final Integer TEST_ID = 7;
     private List<Person> persons;
 
     @Before
     public void setUp() {
-        // initialise test variables
         persons = new ArrayList<>();
         persons.add(personMock);
     }
 
     @Test
     public void test_Home_success() {
-        // given
         when(personServiceMock.getAllPersons()).thenReturn(persons);
 
-        // when
         String result = personController.home(modelMapMock);
 
-        // then
         verify(personServiceMock).getAllPersons();
-
         assertThat(result, is("index"));
     }
 
     @Test
     public void test_AddPerson_success() {
-        // given
         when(bindingResultMock.hasErrors()).thenReturn(false);
-        when(personServiceMock.addPerson(ArgumentMatchers.any(Person.class))).thenReturn(true);
+        when(personMapperMock.toPerson(personDtoMock)).thenReturn(personMock);
 
-        // when
-        String result = personController.addPerson(modelMapMock, personMock, bindingResultMock);
+        String result = personController.addPerson(modelMapMock, personDtoMock, bindingResultMock);
 
-        // then
         verify(bindingResultMock).hasErrors();
+        verify(personMapperMock).toPerson(personDtoMock);
         verify(personServiceMock).addPerson(personMock);
         verify(personServiceMock, never()).getAllPersons();
 
@@ -87,29 +91,28 @@ public class PersonControllerTest {
 
     @Test
     public void test_updatePerson_fail() {
-        // given
         when(bindingResultMock.hasErrors()).thenReturn(true);
 
-        // when
-        String result = personController.updatePerson(modelMapMock, TEST_ID, personMock, bindingResultMock);
+        String result = personController.updatePerson(modelMapMock, TEST_ID, personDtoMock, bindingResultMock);
 
-        // then
         verify(bindingResultMock).hasErrors();
-        verify(personServiceMock, never()).addPerson(personMock);
+        verify(personDtoMock).setId(TEST_ID.longValue());
+        verify(modelMapMock).addAttribute("person", personDtoMock);
+        verify(personServiceMock, never()).addPerson(ArgumentMatchers.any(Person.class));
 
         assertThat(result, is("edit-person"));
     }
 
     @Test
     public void test_updatePerson_success() {
-        // given
         when(bindingResultMock.hasErrors()).thenReturn(false);
+        when(personMapperMock.toPerson(personDtoMock)).thenReturn(personMock);
 
-        // when
-        String result = personController.updatePerson(modelMapMock, TEST_ID, personMock, bindingResultMock);
+        String result = personController.updatePerson(modelMapMock, TEST_ID, personDtoMock, bindingResultMock);
 
-        // then
         verify(bindingResultMock).hasErrors();
+        verify(personDtoMock).setId(TEST_ID.longValue());
+        verify(personMapperMock).toPerson(personDtoMock);
         verify(personServiceMock).addPerson(personMock);
 
         assertThat(result, is("redirect:/"));
@@ -117,45 +120,38 @@ public class PersonControllerTest {
 
     @Test
     public void test_showEditView_success() {
-        // given
         when(personServiceMock.findPersonById(anyLong())).thenReturn(Optional.of(personMock));
+        when(personMapperMock.toPersonDto(personMock)).thenReturn(personDtoMock);
 
-        // when
         String result = personController.showEditView(TEST_ID, modelMock);
 
-        // then
         verify(personServiceMock).findPersonById(anyLong());
-        verify(modelMock).addAttribute("person", personMock);
+        verify(personMapperMock).toPersonDto(personMock);
+        verify(modelMock).addAttribute("person", personDtoMock);
 
         assertThat(result, is("edit-person"));
     }
 
     @Test
     public void test_showEditView_fail() {
-        // given
         when(personServiceMock.findPersonById(anyLong())).thenReturn(Optional.empty());
 
-        // when
         String result = personController.showEditView(TEST_ID, modelMock);
 
-        // then
         verify(personServiceMock).findPersonById(anyLong());
-        verify(modelMock, never()).addAttribute("person", personMock);
+        verify(modelMock, never()).addAttribute("person", personDtoMock);
 
         assertThat(result, is("edit-person"));
     }
 
     @Test
     public void test_AddPerson_fail() {
-        // given
         when(bindingResultMock.hasErrors()).thenReturn(true);
 
-        // when
-        String result = personController.addPerson(modelMapMock, personMock, bindingResultMock);
+        String result = personController.addPerson(modelMapMock, personDtoMock, bindingResultMock);
 
-        // then
         verify(bindingResultMock).hasErrors();
-        verify(personServiceMock, never()).addPerson(personMock);
+        verify(personServiceMock, never()).addPerson(ArgumentMatchers.any(Person.class));
         verify(personServiceMock).getAllPersons();
 
         assertThat(result, is("index"));
@@ -163,13 +159,10 @@ public class PersonControllerTest {
 
     @Test
     public void test_deletePersonById_success() {
-        // given
         when(personServiceMock.findPersonById(TEST_ID.longValue())).thenReturn(Optional.ofNullable(persons.getFirst()));
 
-        // when
         String result = personController.deletePersonById(modelMapMock, TEST_ID);
 
-        // then
         verify(personServiceMock).findPersonById(TEST_ID.longValue());
         verify(personServiceMock).deletePersonById(TEST_ID.longValue());
         verify(personServiceMock, never()).getAllPersons();
@@ -179,13 +172,10 @@ public class PersonControllerTest {
 
     @Test
     public void test_deletePersonById_fail() {
-        // given
         when(personServiceMock.findPersonById(TEST_ID.longValue())).thenReturn(Optional.empty());
 
-        // when
         String result = personController.deletePersonById(modelMapMock, TEST_ID);
 
-        // then
         verify(personServiceMock).findPersonById(TEST_ID.longValue());
         verify(personServiceMock, never()).deletePersonById(TEST_ID.longValue());
         verify(modelMapMock).addAttribute("deleteError", "There are no matching entries to delete");


### PR DESCRIPTION
## Summary
This PR refactors the person add/update flow so the web layer no longer binds the JPA `Person` entity directly.

## Changes
- add `PersonDto` for form binding in add and update flows
- update `PersonController` to accept `PersonDto` in:
  - `addPerson(...)`
  - `updatePerson(...)`
- convert edit form population from `Person` to `PersonDto`
- extract DTO/entity conversion logic into a dedicated `PersonMapper`
- preserve the existing Thymeleaf model attribute name `person` so current templates continue to work without changes

## Why
Binding a persistence entity directly in controller form handlers increases coupling between the web and persistence layers.

This change improves separation of concerns by:
- using a simple DTO/POJO for request binding and validation
- keeping the JPA entity focused on persistence
- moving mapping logic out of the controller into a dedicated component

## Implementation Notes
- validation annotations are applied on `PersonDto`
- `PersonController` now maps `PersonDto` to `Person` before calling `personService.addPerson(...)`
- the update path still uses the path variable `id`, which is set on the DTO before mapping back to the entity
- existing Thymeleaf forms continue to bind against `person`

## Files Changed
- `src/main/java/com/ironoc/db/dto/PersonDto.java`
- `src/main/java/com/ironoc/db/mapper/PersonMapper.java`
- `src/main/java/com/ironoc/db/controller/PersonController.java`

## Related Issue
SonarCloud security issue:
`AZzKbplFbUJJ94dzqUxF`

Reference:
https://sonarcloud.io/project/issues?impactSoftwareQualities=SECURITY&issueStatuses=OPEN%2CCONFIRMED&id=conorheffron_ironoc-db&open=AZzKbplFbUJJ94dzqUxF

## Testing
- verify add employee form submits successfully
- verify add employee validation errors render correctly
- verify edit employee form loads existing values
- verify update employee form submits successfully
- verify update employee validation errors render correctly
- verify no regression in delete flow

## Follow-up
A possible follow-up cleanup would be to remove web validation annotations from the `Person` entity if validation is now intended to live only on the DTO.